### PR TITLE
Add UserDispatch MCP Server to Business & Commerce

### DIFF
--- a/README.md
+++ b/README.md
@@ -716,6 +716,7 @@ The public-facing website is based on the open-source [Directory Website Templat
 - [DealMachine MCP Server](https://mcp.pipedream.com/app/dealmachine) - An MCP server for DealMachine that surfaces its real estate investor tools for direct-to-seller marketing and deal discovery to MCP clients. ([Read more](/details/dealmachine-mcp-server.md)) `real-estate` `Marketing` `lead-generation`
 - [dealx/mcp-server](https://github.com/DealExpress/mcp-server) - MCP Server for the DealX platform, enabling integration and data retrieval in accordance with the MCP protocol. ([Read more](/details/dealxmcp-server.md)) `integration` `business` `platform` `open-source`
 - [DEAR Systems MCP Server](https://mcp.pipedream.com/app/dear) - An MCP Server that connects to DEAR Inventory (DEAR Systems), exposing inventory control, manufacturing, sales, shipping, and payment operations through the MCP interface. ([Read more](/details/dear-systems-mcp-server.md)) `inventory` `E Commerce` `orders`
+- [UserDispatch MCP Server](https://userdispatch.com) - An MCP server for collecting and managing user feedback from AI coding agents. Includes an embeddable feedback widget, submission triage tools, email reply drafting, and weekly digest generation. ([Read more](/details/userdispatch-mcp-server.md)) `customer-feedback` `mcp` `developer-tools`
 
 ## Code Execution & Automation Mcp Servers
 

--- a/details/userdispatch-mcp-server.md
+++ b/details/userdispatch-mcp-server.md
@@ -1,0 +1,44 @@
+# UserDispatch MCP Server
+
+**Category:** Business & Commerce MCP Servers
+**Brand:** UserDispatch
+**Source:** https://github.com/kiruna-labs/userdispatch-mcp
+
+## Overview
+UserDispatch MCP Server is a cloud-hosted MCP server for collecting and managing user feedback directly from AI coding agents. It pairs an embeddable feedback widget (bug reports, ratings, questions) with a full MCP server that exposes tools for submission triage, email reply drafting, and weekly digest generation.
+
+## Features
+- **Embeddable feedback widget**
+  - Drop-in `<script>` tag for any web app
+  - Captures bug reports, feature requests, ratings, and questions
+  - Framework auto-detection (Next.js, Vite, Nuxt, SvelteKit, Astro, static HTML)
+
+- **5 MCP tools**
+  - `submissions` — list, view, reply, update status, delete submissions
+  - `apps` — create and manage feedback apps
+  - `stats` — submission counts and trends
+  - `org` — organization settings
+  - `members` — team member management
+
+- **5 MCP resources**
+  - Recent submissions, submission detail, stats overview, apps list, org overview
+
+- **2 MCP prompts**
+  - `triage-submissions` — review and categorize new submissions
+  - `weekly-digest` — 7-day feedback summary
+
+- **Streamable HTTP transport**
+  - Single endpoint: `https://userdispatch.com/api/mcp`
+  - Bearer token authentication (`ud_` prefixed tokens)
+
+- **One-line install**
+  - `npx userdispatch init` — CLI handles widget injection + MCP config
+
+## Usage
+1. Run `npx userdispatch init` in your project
+2. Sign in via Google OAuth and configure your app
+3. The CLI injects the widget and configures your MCP client
+4. Use MCP tools to triage feedback, draft replies, and track trends
+
+## Pricing
+Free tier available. See https://userdispatch.com for details.


### PR DESCRIPTION
Adds [UserDispatch MCP Server](https://github.com/kiruna-labs/userdispatch-mcp) — a user feedback widget + MCP server for AI coding agents.

- README entry in Business & Commerce section (alphabetical between User.com and Userflow)
- Detail page at `/details/userdispatch-mcp-server.md`
- Tags: `customer-feedback`, `mcp`, `developer-tools`