### PR TITLE
Add 402.bot Discovery Oracle

### DIFF
--- a/README.md
+++ b/README.md
@@ -1242,6 +1242,7 @@ The public-facing website is based on the open-source [Directory Website Templat
 
 ## Search & Discovery Mcp Servers
 
+- [402.bot Discovery Oracle](https://api.402.bot/mcp/setup) - Public remote MCP server for discovering live agent APIs, ranked endpoints, trust signals, and x402 payment telemetry through a read-only streamable HTTP surface. ([Read more](/details/402bot-discovery-oracle.md)) `api-discovery` `x402` `Analytics`
 - [Amazon Kendra Index MCP Server](https://awslabs.github.io/mcp/servers/kendra-index-mcp-server) - An MCP server that connects to Amazon Kendra indexes, providing enterprise search capabilities and retrieval-augmented generation (RAG) enhancement for conversational assistants. ([Read more](/details/amazon-kendra-index-mcp-server.md)) `enterprise-search` `Rag` `Aws`
 - [Barcode Lookup MCP Server](https://mcp.pipedream.com/app/barcode_lookup) - Barcode Lookup MCP Server is an MCP server integration for the Barcode Lookup service, enabling MCP-based tools to search millions of products online by barcode via a standardized protocol interface. ([Read more](/details/barcode-lookup-mcp-server.md)) `product-data` `Search` `lookup`
 - [BrandMentions MCP Server](https://mcp.pipedream.com/app/brandmentions) - An MCP Server that integrates with BrandMentions, enabling MCP clients to monitor and query brand mentions across the web. ([Read more](/details/brandmentions-mcp-server.md)) `brand-monitoring` `social-sentiment` `web-search`

--- a/details/402bot-discovery-oracle.md
+++ b/details/402bot-discovery-oracle.md
@@ -1,0 +1,42 @@
+# 402.bot Discovery Oracle
+
+[Website](https://api.402.bot/mcp/setup)  
+[Runtime](https://api.402.bot/mcp)  
+[Public Repo](https://github.com/sam00101011/402.bot-public)
+
+## Description
+402.bot Discovery Oracle is a public, read-only remote MCP server for discovering live agent APIs and inspecting endpoint trust, routing activity, and x402 payment telemetry. It is designed as a discovery-first surface so agents can search and inspect capabilities without needing to handle paid x402 execution on the MCP layer.
+
+## Features
+- **Live endpoint discovery:** Search ranked endpoints by capability, network, strategy, and discovery source.
+- **Endpoint inspection:** Inspect trust signals, probe freshness, payment activity, and routing telemetry for individual endpoints.
+- **Agent analytics:** Inspect wallet-level routing and payment behavior across the x402 ecosystem.
+- **Remote MCP access:** Hosted at a public `streamable-http` endpoint with no API key required for the v1 read-only surface.
+- **Companion setup/docs:** Includes a public setup page and `llms.txt` for fast installation in major MCP clients.
+
+## Tools
+- `discover_endpoints`
+- `inspect_endpoint`
+- `inspect_agent`
+
+## Resources
+- `agent-metadata`
+- `capability-catalog`
+- `top-capabilities`
+- `example-queries`
+- `paid-surfaces`
+- `setup-notes`
+
+## Pricing
+- **Free** for the public discovery and inspection MCP surface in v1.
+- **Paid x402 execution** remains on the HTTP APIs rather than the MCP interface in v1.
+
+## Technical Notes
+- Transport: `streamable-http`
+- Runtime: `https://api.402.bot/mcp`
+- Setup docs: `https://api.402.bot/mcp/setup`
+- `llms.txt`: `https://402.bot/llms.txt`
+
+## Source
+- [https://api.402.bot/mcp/setup](https://api.402.bot/mcp/setup)
+- [https://github.com/sam00101011/402.bot-public](https://github.com/sam00101011/402.bot-public)


### PR DESCRIPTION
Adds 402.bot Discovery Oracle to the Search & Discovery section and includes a companion detail page.\n\nPublic repo: https://github.com/sam00101011/402.bot-public\nRuntime: https://api.402.bot/mcp\nSetup/docs: https://api.402.bot/mcp/setup\nllms.txt: https://402.bot/llms.txt