### PR TITLE
Add iz-tolk-mcp to Blockchain & Crypto Mcp Servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -478,6 +478,7 @@ The public-facing website is based on the open-source [Directory Website Templat
 - [crypto-trending-mcp](https://github.com/kukapay/crypto-trending-mcp) - An MCP server that tracks the latest trending tokens on CoinGecko for AI-powered analysis. ([Read more](/details/crypto-trending-mcp.md)) `mcp` `crypto` `market-data` `Real Time`
 - [crypto-whitepapers-mcp](https://github.com/kukapay/crypto-whitepapers-mcp) - An MCP server serving as a structured knowledge base of crypto whitepapers for AI agents. ([Read more](/details/crypto-whitepapers-mcp.md)) `mcp` `crypto` `Knowledge Base` `Documentation`
 - [cryptopanic-mcp-server](https://github.com/kukapay/cryptopanic-mcp-server) - An MCP server providing the latest cryptocurrency news to AI agents, powered by CryptoPanic. ([Read more](/details/cryptopanic-mcp-server.md)) `mcp` `crypto` `news` `ai-integration`
+- [iz-tolk-mcp](https://github.com/izzzzzi/izTolkMcp) - MCP server for the Tolk smart contract compiler on the TON blockchain. Compile, syntax check, deploy link generation, language docs, stdlib, and contract prompts. `mcp` `blockchain` `ton` `smart-contracts`
 
 ## Business & Commerce Mcp Servers
 


### PR DESCRIPTION
## Summary

- Adds **[iz-tolk-mcp](https://github.com/izzzzzi/izTolkMcp)** to the **Blockchain & Crypto Mcp Servers** section in alphabetical order.
- iz-tolk-mcp is an MCP server for the Tolk smart contract compiler on the TON blockchain.
- Features: compile, syntax check, deploy link generation, language docs, stdlib, and contract prompts.
- Provides 4 tools, 6 resources, and 3 prompts.
- Available on npm as `iz-tolk-mcp`
- Written in TypeScript, MIT licensed

## Details

| Field | Value |
|-------|-------|
| GitHub | https://github.com/izzzzzi/izTolkMcp |
| npm | [iz-tolk-mcp](https://www.npmjs.com/package/iz-tolk-mcp) |
| Language | TypeScript |
| License | MIT |