### PR TITLE
Add operant-mcp to Security & Attestation category

### DIFF
--- a/README.md
+++ b/README.md
@@ -680,6 +680,7 @@ The public-facing website is based on the open-source [Directory Website Templat
 - [Control D MCP Server](https://mcp.pipedream.com/app/control_d) - An MCP Server integration for Control D, enabling programmable control over its customizable DNS service for blocking threats, unwanted content, and ads. ([Read more](/details/control-d-mcp-server.md)) `dns` `Security` `content-filtering`
 - [Conveyor MCP Server](https://mcp.pipedream.com/app/conveyor) - An MCP server exposing Conveyor’s security review and questionnaire automation platform to MCP-compatible agents, enabling programmatic access to security review workflows. ([Read more](/details/conveyor-mcp-server.md)) `Security` `questionnaires` `compliance`
 - [DataTrails MCP Server](https://mcp.pipedream.com/app/rkvst) - An MCP Server for DataTrails (formerly RKVST), exposing APIs to add provenance and verify authenticity of digital content within MCP-automated workflows. ([Read more](/details/datatrails-mcp-server.md)) `attestation` `provenance` `verification`
+- [operant-mcp](https://github.com/operantlabs/operant-mcp) - Security testing MCP server with 51 tools for penetration testing, network forensics, memory analysis, and vulnerability assessment. Install via `npx operant-mcp`. ([Read more](/details/operant-mcp.md)) `Security` `penetration-testing` `forensics`
 
 ## Api Integration Mcp Servers
 

--- a/details/operant-mcp.md
+++ b/details/operant-mcp.md
@@ -1,0 +1,32 @@
+# operant-mcp
+
+[GitHub Source](https://github.com/operantlabs/operant-mcp)
+
+**Category:** Security & Attestation MCP Servers
+**Tags:** security, penetration-testing, forensics, vulnerability-assessment
+
+---
+
+## Description
+
+operant-mcp is a TypeScript-based MCP server providing 51 security testing tools for AI-assisted penetration testing, network forensics, memory analysis, and vulnerability assessment. It enables AI agents to perform comprehensive security testing workflows through the Model Context Protocol.
+
+---
+
+## Features
+
+- **Penetration Testing**: SQL injection, XSS, SSRF, command injection, path traversal, and deserialization testing tools.
+- **Network Forensics**: PCAP analysis including stream following, DNS analysis, TLS inspection, credential extraction, and scan detection.
+- **Memory Analysis**: Volatility-based memory forensics for both Windows and Linux, including rootkit detection.
+- **Vulnerability Assessment**: Authentication brute forcing, CSRF extraction, cookie tampering, CORS testing, clickjacking detection, and IDOR testing.
+- **Reconnaissance**: DNS enumeration, directory brute forcing, S3 bucket discovery, TLS SAN extraction, virtual host enumeration, and Git secrets scanning.
+- **Cloud Security**: CloudTrail log analysis and anomaly detection, SSRF cloud metadata testing.
+- **GraphQL Security**: Introspection and hidden endpoint discovery.
+- **Business Logic Testing**: Price manipulation, coupon abuse, and role escalation testing.
+- **Easy Installation**: Install and run via `npx operant-mcp`.
+
+---
+
+## Pricing
+
+operant-mcp is open source and available under the MIT license on GitHub. No pricing or paid tiers.


### PR DESCRIPTION
## Summary
- Adds [operant-mcp](https://github.com/operantlabs/operant-mcp) to the **Security & Attestation MCP Servers** category
- Includes README entry and detailed description file in `/details/operant-mcp.md`
- Security testing MCP server with 51 tools for penetration testing, network forensics, memory analysis, and vulnerability assessment
- TypeScript, MIT licensed
- Install: `npx operant-mcp`