### PR TITLE
feat: add KubeStellar Console MCP server

### DIFF
--- a/details/kubestellar-console.md
+++ b/details/kubestellar-console.md
@@ -1,0 +1,21 @@
+## Features
+
+- Multi-cluster Kubernetes dashboard with built-in MCP server (kc-agent)
+- Bridges kubeconfig contexts to LLMs for natural-language cluster management
+- AI-assisted operations across edge and cloud clusters
+- Real-time observability and CNCF project integrations
+- Written in Go with Apache-2.0 license
+
+## Use Cases
+
+- AI-powered multi-cluster Kubernetes management via natural language
+- Cross-cluster resource monitoring and operations
+- LLM-assisted troubleshooting and workload optimization
+
+## Comparison to kubectl MCP servers
+
+KubeStellar Console provides a full dashboard UI alongside its MCP server, with built-in multi-cluster support and CNCF project integrations, rather than just exposing kubectl commands.
+
+## Pricing
+
+Free and open source (Apache-2.0). CNCF Sandbox project.


### PR DESCRIPTION
Add [KubeStellar Console](https://github.com/kubestellar/console) as an MCP server entry.

KubeStellar Console is a multi-cluster Kubernetes dashboard with a built-in MCP server (kc-agent) written in Go that bridges kubeconfig contexts to LLMs for natural-language cluster management.

- **Repo:** https://github.com/kubestellar/console
- **Language:** Go
- **License:** Apache-2.0
- **CNCF Sandbox project**