### PR TITLE
Add NotFair under Marketing

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,7 +215,7 @@ The public-facing website is based on the open-source [Directory Website Templat
 - [Knowledge Management Memory (1)](#knowledge-management-memory-1)
 - [Knowledge Mcp Servers (4)](#knowledge-mcp-servers)
 - [Location Services (30)](#location-services)
-- [Marketing (28)](#marketing)
+- [Marketing (29)](#marketing)
 - [Marketing & Sales MCP Servers (3)](#marketing--sales-mcp-servers)
 - [MCP DevTools (5)](#mcp-devtools)
 - [MCP Middleware & Orchestration (30)](#mcp-middleware--orchestration-1)
@@ -4332,6 +4332,7 @@ The public-facing website is based on the open-source [Directory Website Templat
 - [mailchimp-mcp-server](https://github.com/damientilman/mailchimp-mcp-server) - Mailchimp Marketing API with 53 tools for campaigns, audiences, reports, automations, landing pages. ([Read more](/details/mailchimp-mcp-server.md)) `Email Marketing` `Python` `Cloud`
 - [mcp-metricool](https://github.com/metricool/mcp-metricool) - Facilitates AI-driven analysis and scheduling of social media metrics and campaigns via the Metricool API. ([Read more](/details/metricool-mcp-metricool.md)) `Open Source` `Social Media` `Analytics`
 - [Meta Ads MCP](https://github.com/pipeboard/meta-ads-mcp) - Community-built open-source MCP servers for Meta Ads API (Facebook, Instagram), enabling read-write campaign management including creation, modification, pausing, and creative analysis. ([Read more](/details/meta-ads-mcp.md)) `Read Write` `Open Source` `Ad Platform`
+- [NotFair](https://notfair.co) - Hosted Google Ads MCP server connecting Claude and AI agents to Google Ads accounts. Diagnoses campaign performance (CPA, ROAS, search-term waste, quality scores), recommends optimizations (bids, budgets, negative keywords, ad copy), and executes approved changes via the official Google Ads API with a built-in human-approval gate. Free tier available. ([Read more](/details/notfair.md)) `Google Ads` `Advertising` `Cloud`
 - [Pinterest Ads MCP](https://twominutereports.com/integrations/pinterest-ads-mcp) - Connects Pinterest Ads to Claude or ChatGPT via Two Minute Reports MCP to get insights into Pin clicks, outbound clicks, engagement rate and conversions. ([Read more](/details/pinterest-ads-mcp.md)) `Ads` `Pinterest` `Analytics`
 - [producthunt-mcp-server](https://github.com/jaipandya/producthunt-mcp-server) - Connects Product Hunt's API to any LLM or agent using the Model Context Protocol for seamless data integration and automation. ([Read more](/details/jaipandya-producthunt-mcp-server.md)) `Open Source` `Product Hunt` `Api`
 - [robotstxt-ai](https://github.com/sharozdawa/robotstxt-ai) - Visual robots.txt manager for AI crawlers. Supports toggle controls for 20+ bots including GPTBot, ClaudeBot, and PerplexityBot to control AI scraping. ([Read more](/details/robotstxt-ai.md)) `Seo` `Ai Crawler` `Open Source`

--- a/details/notfair.md
+++ b/details/notfair.md
@@ -1,0 +1,15 @@
+## Overview
+
+NotFair is a hosted Google Ads MCP server that connects Claude and other AI agents (Cursor, Codex, etc.) to a Google Ads account. The server enables AI assistants to diagnose campaign performance, recommend optimizations, and execute approved changes via the official Google Ads API.
+
+## Features
+
+- Diagnoses campaign performance: CPA, ROAS, search-term waste, quality scores, learning-phase status
+- Recommends bid moves, budget reallocations, negative keywords, ad-copy changes, audience refinements
+- Executes approved changes via the official Google Ads API with a built-in human-approval gate
+- Remote MCP endpoint with full OAuth 2.1 (dynamic client registration) at `https://notfair.co/api/mcp/google_ads`
+- Works with any MCP-compatible client (Claude Desktop, Claude Code, Cursor, Cline, Codex CLI)
+
+## Pricing
+
+Free tier plus paid plans. See [notfair.co](https://notfair.co) for details.


### PR DESCRIPTION
Adding NotFair under the Marketing section. It's a hosted Google Ads MCP server that lets Claude and other AI agents diagnose campaign performance, recommend optimizations (bids, budgets, negative keywords, ad copy), and execute approved changes via the official Google Ads API with a built-in human-approval gate.

Inserted alphabetically between Meta Ads MCP and Pinterest Ads MCP. Bumped the section count in the table of contents from 28 to 29. Added a short `details/notfair.md` matching the format of the other Marketing entries.

Free tier available. The remote endpoint is `https://notfair.co/api/mcp/google_ads` with full OAuth 2.1 (dynamic client registration) — works with Claude Desktop, Claude Code, Cursor, and any MCP-compatible client. Happy to adjust placement, wording, or category if you'd prefer.