### PR TITLE
Add Pictify MCP server — image, GIF, and PDF generation

### DIFF
--- a/details/pictify-mcp-server.md
+++ b/details/pictify-mcp-server.md
@@ -1,0 +1,8 @@
+Pictify is an MCP server that lets AI agents render images, animated GIFs, and PDFs from HTML/CSS, live URLs, or reusable Handlebars/FabricJS templates. In a single agent turn you can generate OG images, social cards, banners, screenshots, PDF invoices, certificates, and animated GIFs — or run a batch of up to 100 personalised renders. Built-in A/B experiment tooling lets you split-test image variants with traffic splitting and auto-optimization.
+
+Works with Claude (claude.ai + Claude Desktop + Claude Code), Cursor, Windsurf, and any MCP-compatible client. Available as a hosted remote server or self-hosted via npm.
+
+- [GitHub Repository](https://github.com/pictify-io/mcp)
+- [npm Package](https://www.npmjs.com/package/@pictify/mcp-server)
+- [Hosted Remote Server](https://mcp.pictify.io)
+- [Official MCP Registry](https://registry.modelcontextprotocol.io/servers/io.github.pictify-io~mcp)


### PR DESCRIPTION
Adds a detail file for [Pictify](https://github.com/pictify-io/mcp) under **Media Processing**.

Pictify is an MCP server for rendering images, animated GIFs, and PDFs from HTML/CSS, live URLs, or reusable templates — directly from AI agents. Batch up to 100 personalised renders per request, A/B test variants.

- **Hosted remote:** `https://mcp.pictify.io`
- **Self-hosted:** `npx -y @pictify/mcp-server`
- **npm:** https://www.npmjs.com/package/@pictify/mcp-server (`@pictify/mcp-server@1.2.1`)
- **License:** MIT
- **Official MCP Registry:** `io.github.pictify-io/mcp`

Suggested tags: `Image Generation` `Templates` `PDF` `GIF` `Media`