### PR TITLE
Add NotFair — open-source Claude Code skills for SEO, Google Ads & Meta Ads

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,7 +215,7 @@ The public-facing website is based on the open-source [Directory Website Templat
 - [Knowledge Management Memory (1)](#knowledge-management-memory-1)
 - [Knowledge Mcp Servers (4)](#knowledge-mcp-servers)
 - [Location Services (30)](#location-services)
-- [Marketing (28)](#marketing)
+- [Marketing (29)](#marketing)
 - [Marketing & Sales MCP Servers (3)](#marketing--sales-mcp-servers)
 - [MCP DevTools (5)](#mcp-devtools)
 - [MCP Middleware & Orchestration (30)](#mcp-middleware--orchestration-1)
@@ -4332,6 +4332,7 @@ The public-facing website is based on the open-source [Directory Website Templat
 - [mailchimp-mcp-server](https://github.com/damientilman/mailchimp-mcp-server) - Mailchimp Marketing API with 53 tools for campaigns, audiences, reports, automations, landing pages. ([Read more](/details/mailchimp-mcp-server.md)) `Email Marketing` `Python` `Cloud`
 - [mcp-metricool](https://github.com/metricool/mcp-metricool) - Facilitates AI-driven analysis and scheduling of social media metrics and campaigns via the Metricool API. ([Read more](/details/metricool-mcp-metricool.md)) `Open Source` `Social Media` `Analytics`
 - [Meta Ads MCP](https://github.com/pipeboard/meta-ads-mcp) - Community-built open-source MCP servers for Meta Ads API (Facebook, Instagram), enabling read-write campaign management including creation, modification, pausing, and creative analysis. ([Read more](/details/meta-ads-mcp.md)) `Read Write` `Open Source` `Ad Platform`
+- [NotFair](https://github.com/nowork-studio/NotFair) - Open-source Claude Code skills for SEO, GEO, Google Ads, and Meta Ads. Connects to live data via Google Ads MCP, Meta Ads MCP, Google Search Console MCP, and Google Analytics (GA4) MCP. Covers site analysis, keyword research, meta tags, schema markup, wasted-spend detection, ROAS analysis, and creative fatigue. ([Read more](/details/notfair-skills.md)) `Open Source` `Claude Code` `Seo` `Google Ads` `Meta Ads`
 - [Pinterest Ads MCP](https://twominutereports.com/integrations/pinterest-ads-mcp) - Connects Pinterest Ads to Claude or ChatGPT via Two Minute Reports MCP to get insights into Pin clicks, outbound clicks, engagement rate and conversions. ([Read more](/details/pinterest-ads-mcp.md)) `Ads` `Pinterest` `Analytics`
 - [producthunt-mcp-server](https://github.com/jaipandya/producthunt-mcp-server) - Connects Product Hunt's API to any LLM or agent using the Model Context Protocol for seamless data integration and automation. ([Read more](/details/jaipandya-producthunt-mcp-server.md)) `Open Source` `Product Hunt` `Api`
 - [robotstxt-ai](https://github.com/sharozdawa/robotstxt-ai) - Visual robots.txt manager for AI crawlers. Supports toggle controls for 20+ bots including GPTBot, ClaudeBot, and PerplexityBot to control AI scraping. ([Read more](/details/robotstxt-ai.md)) `Seo` `Ai Crawler` `Open Source`

--- a/details/notfair-skills.md
+++ b/details/notfair-skills.md
@@ -1,0 +1,14 @@
+## Overview
+
+NotFair is an open-source set of Claude Code skills for SEO, GEO, Google Ads, and Meta Ads. It connects to live marketing data through Google Ads MCP, Meta Ads MCP, Google Search Console MCP, and Google Analytics (GA4) MCP.
+
+## Features
+
+- SEO: site analysis, keyword research, meta tags optimization, schema markup generation, GEO optimization, content writing
+- Google Ads: campaign audits, wasted-spend detection, search-term cleanup, keyword and bid management
+- Meta Ads: ROAS analysis, creative fatigue detection, audience overlap identification
+- Integrates with Google Ads MCP, Meta Ads MCP, Google Search Console MCP, and Google Analytics (GA4) MCP
+
+## Pricing
+
+Free and open-source (MIT license).


### PR DESCRIPTION
Thanks for maintaining this list — it's a great reference.

I'd like to add [NotFair](https://github.com/nowork-studio/NotFair) (~2.9k stars, MIT license) to the **Marketing** section. It's an open-source collection of Claude Code agent skills covering SEO, Google Ads, and Meta Ads. What makes it relevant here is that it connects directly to real MCP servers: Google Ads MCP, Meta Ads MCP, Google Search Console MCP, and Google Analytics (GA4) MCP — so it's genuinely in the MCP ecosystem rather than just a standalone tool.

The skill areas include site audits, keyword research, meta tags, schema markup, GEO optimization, wasted-spend detection, search-term cleanup, ROAS analysis, and creative fatigue detection.

I've inserted it alphabetically between "Meta Ads MCP" and "Pinterest Ads MCP" and added a brief `details/notfair-skills.md` following the existing format.

Happy to reword, move to a different section, or trim the entry if you prefer.