### PR TITLE
Add DottedSign to Document Management MCP Servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ The public-facing website is based on the open-source [Directory Website Templat
 - [Development Tools MCP Servers (7)](#development-tools-mcp-servers-2)
 - [DevOps & CI/CD MCP Servers (4)](#devops--cicd-mcp-servers)
 - [DevOps & Cloud MCP Servers (1)](#devops--cloud-mcp-servers)
-- [Document Management Mcp Servers (13)](#document-management-mcp-servers)
+- [Document Management Mcp Servers (14)](#document-management-mcp-servers)
 - [Document Management MCP Servers (10)](#document-management-mcp-servers-1)
 - [Document Management MCP Servers (2)](#document-management-mcp-servers-2)
 - [Documentation (1)](#documentation)
@@ -3506,6 +3506,7 @@ The public-facing website is based on the open-source [Directory Website Templat
 - [Basic Memory](https://github.com/modelcontextprotocol/servers/tree/main/src/basic-memory) - Local-first knowledge management system that builds a semantic graph from Markdown files, enabling persistent memory across conversations with LLMs. ([Read more](/details/basic-memory.md)) `Knowledge Management` `Local First` `Semantic Graph`
 - [BoldSign](https://github.com/modelcontextprotocol/servers/tree/main/src/boldsign) - Search, request, and manage e-signature contracts effortlessly with BoldSign. This MCP server enables AI agents to handle document signing workflows and contract management. ([Read more](/details/boldsign.md)) `E Signature` `Contracts` `Document Management`
 - [CLDGeminiPDF Analyzer](https://github.com/modelcontextprotocol/servers/tree/main/src/cld-gemini-pdf-analyzer) - MCP server tool enabling sharing large PDF files to Google LLMs via API for further/additional analysis and response retrieval to Claude Desktop. ([Read more](/details/cldgeminipdf-analyzer.md)) `Pdf` `Gemini` `Document Analysis`
+- [DottedSign](https://github.com/DottedSign-Official/dottedsign-mcp) - MCP server for DottedSign eSignature, letting AI assistants create signing tasks from templates, send documents for signature, and track signing status through natural language. ([Read more](/details/dottedsign.md)) `E Signature` `Contracts` `Document Management`
 - [Evernote Notes MCP Server](https://github.com/brentmid/evernote-mcp-server) - Local MCP server connecting Claude Desktop and MCP-compatible LLMs with Evernote accounts, enabling contextual queries and searches over notes using natural language with secure local access. ([Read more](/details/evernote-notes-mcp-server.md)) `Evernote` `Notes` `Search`
 - [Kiteworks](https://www.kiteworks.com) - Official MCP server for interacting with the Kiteworks Private Data Network (PDN) platform, enabling secure enterprise file sharing and document management. ([Read more](/details/kiteworks.md)) `Enterprise` `Data Security` `File Sharing`
 - [Klavis ReportGen](https://klavis.ai) - MCP server for creating professional reports from simple user queries, enabling AI agents to generate structured reports automatically. ([Read more](/details/klavis-reportgen.md)) `Reporting` `Professional Reports` `Automation`

--- a/details/dottedsign.md
+++ b/details/dottedsign.md
@@ -1,0 +1,35 @@
+# DottedSign
+
+**Category:** Document Management Mcp Servers  
+**Tags:** esignature, contracts, document-management, signing, ai-assistant  
+**Source:** [github.com/DottedSign-Official/dottedsign-mcp](https://github.com/DottedSign-Official/dottedsign-mcp)
+
+## Description
+DottedSign MCP is a remote MCP server that lets AI assistants (Claude, Claude Code, ChatGPT) run a complete eSignature workflow through natural language — create signing tasks from templates, arrange the signing order, send documents to signers, track status, and manage completed contracts. It connects over streamable HTTP with OAuth authorization, so no API keys or coding are required.
+
+## Features
+- **Natural-language eSignature workflow:** Create, send, and manage signing tasks by chatting with your AI assistant.
+- **Template-based tasks:** Quickly create a signing task from a saved DottedSign template.
+- **Signing order control:** Arrange who signs first and route each task to the right recipients.
+- **Status tracking:** Check the real-time status of pending, waiting, completed, and canceled tasks.
+- **Task management:** Read task content, void or cancel tasks, and get download links for completed documents.
+- **Multi-client support:** Works with Claude Desktop, Claude web, Claude Code, and ChatGPT.
+- **Secure OAuth authorization:** Access is granted through DottedSign's OAuth flow and can be revoked at any time.
+
+## Requirements
+- A DottedSign account (sending signing tasks requires a paid plan)
+- An MCP-compatible AI client (Claude, Claude Code, or ChatGPT)
+
+## Installation
+- Claude / ChatGPT: add a Connector with the URL `https://mcp.dottedsign.com/dottedsign-api/mcp`
+- Claude Code: `claude mcp add --transport http dottedsign https://mcp.dottedsign.com/dottedsign-api/mcp`
+- Authorize access by signing in to DottedSign on first use
+
+## Pricing
+The MCP connector is free and works on free AI accounts. A DottedSign account is required; full AI-powered sending features require a paid DottedSign plan (Business recommended).
+
+## Additional Notes
+- Remote server (streamable-http), endpoint `https://mcp.dottedsign.com/dottedsign-api/mcp`.
+- Recipients sign through the normal DottedSign email link — no AI tool or account required on their side.
+
+---


### PR DESCRIPTION
Adds **DottedSign**, a remote (streamable-http) MCP server that lets AI assistants (Claude, Claude Code, ChatGPT) run a full eSignature workflow through natural language — create signing tasks from templates, send documents for signature, and track signing status.

- Repo: https://github.com/DottedSign-Official/dottedsign-mcp
- Endpoint: `https://mcp.dottedsign.com/dottedsign-api/mcp` (OAuth, no API key needed)
- Category: Document Management MCP Servers (alongside BoldSign / PandaDoc / Nutrient)

Changes:
- Add `details/dottedsign.md`
- Add the entry under **Document Management Mcp Servers** in `README.md` and bump the category count in the Table of Contents