### PR TITLE
Add Ghost in the Droid — 62-tool Android+iOS MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -4608,6 +4608,7 @@ The public-facing website is based on the open-source [Directory Website Templat
 
 ## OS Automation
 
+- [Ghost in the Droid](https://github.com/ghost-in-the-droid/android-agent) - Give any LLM agent a real Android or iPhone as its body. 62 MCP tools for tap, swipe, screenshot, UI accessibility tree inspection, app launch, ADB shell, and on-device inference (llama.cpp / MediaPipe / MLX). Install: `pip install ghost-in-the-droid`. ([Read more](/details/ghost-in-the-droid.md)) `Mobile` `Android` `Ios` `Python` `On Device Ai`
 - [toolkit-mcp-server](https://github.com/search?q=toolkit-mcp-server) - Model Context Protocol server providing LLM Agents with system utilities including IP geolocation, network diagnostics, system monitoring, cryptographic operations, and QR code generation. ([Read more](/details/toolkit-mcp-server.md)) `Utilities` `Geolocation` `Crypto`
 
 ## Other Tools And Integrations


### PR DESCRIPTION
## Summary

Adds [Ghost in the Droid](https://github.com/ghost-in-the-droid/android-agent) to the **OS Automation** section.

**What it is:** A Python MCP server that gives any LLM agent real Android or iPhone hands — 62 tools covering tap, swipe, screenshot, UI accessibility tree, app launch, ADB shell, and on-device inference (llama.cpp / MediaPipe / MLX).

**Install:** `pip install ghost-in-the-droid`

**Platforms:** macOS, Windows, Linux (via ADB for Android; iOS via local toolchain)

## Entry added

```
- [Ghost in the Droid](https://github.com/ghost-in-the-droid/android-agent) - Give any LLM agent a real Android or iPhone as its body. 62 MCP tools for tap, swipe, screenshot, UI accessibility tree inspection, app launch, ADB shell, and on-device inference (llama.cpp / MediaPipe / MLX). Install: `pip install ghost-in-the-droid`. `Mobile` `Android` `Ios` `Python` `On Device Ai`
```