### PR TITLE
Add Autoposting MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ The public-facing website is based on the open-source [Directory Website Templat
 - [Search & Discovery Mcp Servers (30)](#search--discovery-mcp-servers)
 - [Security Attestation Mcp Servers (30)](#security-attestation-mcp-servers)
 - [Security MCP Servers (2)](#security-mcp-servers)
-- [Social (6)](#social)
+- [Social (7)](#social)
 - [Testing (1)](#testing)
 - [Travel & Transportation (26)](#travel--transportation)
 - [Version Control (23)](#version-control)
@@ -1914,6 +1914,7 @@ The public-facing website is based on the open-source [Directory Website Templat
 - [Postiz MCP Server](https://postiz.com) - Open-source social media scheduling tool with MCP server support, enabling self-hosted content management across multiple platforms. Features AI-powered content generation, team collaboration tools, calendar content planning views, and an analytics dashboard for multi-platform social media management. ([Read more](/details/postiz-mcp-server.md)) `Open Source` `Self Hosted` `Multi Platform`
 - [TikTok MCP](https://github.com/Seym0n/tiktok-mcp) - MCP server for interacting with TikTok videos. ([Read more](/details/tiktok-mcp.md)) `Tiktok` `Videos` `Social Media`
 - [Xpoz MCP](https://www.xpoz.ai) - MCP server providing comprehensive access to social media data across Twitter/X, Instagram, TikTok, and Reddit through a single integration with over 1.5 billion indexed posts. Enables natural language queries for social media intelligence without API keys or coding. ([Read more](/details/xpoz-mcp.md)) `Social Media` `Natural Language` `Multi Platform`
+- [Autoposting MCP Server](https://github.com/Autoposting-ai/autoposting-mcp) - Hosted MCP server for social media publishing. Draft and rewrite posts, generate ideas with AI agents, build carousels, clip and render video, search a knowledge base, manage brands and webhooks, and schedule or publish to X, LinkedIn, Instagram, Threads and YouTube. Streamable HTTP with OAuth 2.1 Dynamic Client Registration, nothing to install locally. ([Read more](/details/autoposting-mcp-server.md)) `Social Media` `Scheduling` `Multi Platform`
 
 ## Testing
 

--- a/details/autoposting-mcp-server.md
+++ b/details/autoposting-mcp-server.md
@@ -1,0 +1,44 @@
+## Overview
+
+Autoposting is a hosted MCP server that gives an AI client full control of a social media workflow: draft and rewrite posts, generate ideas with AI agents, build carousels, clip and render video, search a knowledge base, manage brands and webhooks, and schedule or publish to X, LinkedIn, Instagram, Threads and YouTube. It speaks Streamable HTTP and authenticates with OAuth 2.1 Dynamic Client Registration, so there is no client ID or secret to configure and nothing to install locally.
+
+## Features
+
+- 69 tools across posts, ideas and agents, brands, knowledge base, carousels, video clips, webhooks, and organizations
+- Schedule and publish to X, LinkedIn, Instagram, Threads and YouTube
+- AI idea generation and post rewriting
+- Carousel generation and drafting
+- Video clip import, rendering, and management
+- Knowledge base ingestion and search
+- Brand and webhook management
+- Tools filtered per connection by OAuth scope
+- MCP annotations on every tool so a client can tell reads from writes and confirm before a destructive call
+
+## Setup
+
+Claude Code:
+```
+claude mcp add --transport http autoposting https://app.autoposting.ai/mcp
+```
+
+Claude Desktop / Cursor / generic client:
+```json
+{
+  "mcpServers": {
+    "autoposting": {
+      "type": "http",
+      "url": "https://app.autoposting.ai/mcp"
+    }
+  }
+}
+```
+
+OAuth 2.1 Dynamic Client Registration handles authentication, so no client ID or secret needs to be configured.
+
+## Pricing
+
+Requires an Autoposting account. See https://autoposting.ai for plan details.
+
+## Best For
+
+Teams and creators who want an AI client to run a multi-platform social media workflow end to end without installing or hosting anything.


### PR DESCRIPTION
Adds Autoposting to the Social section, with a matching `details/autoposting-mcp-server.md` page and an updated TOC count.

Autoposting is a hosted MCP server for social media publishing: draft and rewrite posts, generate ideas with AI agents, build carousels, clip and render video, search a knowledge base, manage brands and webhooks, and schedule or publish to X, LinkedIn, Instagram, Threads and YouTube.

- Endpoint: `https://app.autoposting.ai/mcp`
- Transport: Streamable HTTP with OAuth 2.1 Dynamic Client Registration — no client ID/secret to configure, nothing to install locally.
- Docs: https://docs.autoposting.ai/mcp/overview
- Published in the official MCP registry as `ai.autoposting/autoposting`.
