### PR TITLE
Add AdMapix to Marketing MCP servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -4315,6 +4315,7 @@ The public-facing website is based on the open-source [Directory Website Templat
 
 ## Marketing
 
+- [AdMapix](https://www.admapix.com/) - MCP server for searching competitor ad creatives by keyword, country, date, and creative type. ([Read more](/details/admapix.md)) `Advertising` `Research` `Python`
 - [ai-visibility](https://github.com/sharozdawa/ai-visibility) - Tracks brand visibility across ChatGPT, Perplexity, Claude, and Gemini. Offers visibility scores, sentiment analysis, and competitor detection for marketing insights. ([Read more](/details/ai-visibility.md)) `Open Source` `Ai` `Sentiment`
 - [ai-visibility](https://github.com/sharozdawa/ai-visibility) - Track brand visibility across ChatGPT, Perplexity, Claude, and Gemini with visibility scores, sentiment analysis, and competitor detection. MCP server for AI-driven brand monitoring. ([Read more](/details/sharozdawa-ai-visibility.md)) `Open Source` `Ai` `Sentiment Analysis`
 - [apollo-io-mcp](https://github.com/louis030195/apollo-io-mcp) - B2B sales intelligence with Apollo.io: prospect search, contact enrichment, company discovery from 275M+ contacts. ([Read more](/details/apollo-io-mcp.md)) `Sales` `B2b` `Multi Platform`

--- a/details/admapix.md
+++ b/details/admapix.md
@@ -1,0 +1,26 @@
+## Overview
+
+[AdMapix](https://www.admapix.com/) is an MCP server that lets compatible AI agents search competitor advertising creatives and receive structured raw data.
+
+## Features
+
+- Search by keyword, app name, advertiser, category, or ad copy
+- Filter by creative type, country, date range, and industry
+- Sort by first seen, relevance, estimated impressions, or days active
+- Return structured creative records with media URLs and metrics
+
+## Installation
+
+The published Python package is available on [PyPI](https://pypi.org/project/admapix-mcp/):
+
+```bash
+pip install admapix-mcp
+```
+
+Configure the `ADMAPIX_API_KEY` environment variable before starting the server.
+
+## Sources
+
+- [Official website](https://www.admapix.com/)
+- [PyPI package](https://pypi.org/project/admapix-mcp/)
+- [Source repository](https://github.com/fly0pants/admapix)


### PR DESCRIPTION
Adds AdMapix to the Marketing section with a concise details page.

- Official website: https://www.admapix.com/
- PyPI package: https://pypi.org/project/admapix-mcp/
- Source repository: https://github.com/fly0pants/admapix
- The description is limited to the documented `search_creatives` MCP capability and `ADMAPIX_API_KEY` setup.