### PR TITLE
docs: add SandBase Harness MCP runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -1646,6 +1646,7 @@ The public-facing website is based on the open-source [Directory Website Templat
 - [script-mcp](https://github.com/nguyenvanduocit/script-mcp) - MCP server for running scripts, enabling LLMs to execute various script types through the Model Context Protocol. ([Read more](/details/script-mcp.md)) `Scripting` `Automation` `Code Execution`
 - [Secure Shell MCP Server](https://github.com/blazickjp/secure-shell-mcp) - Secure shell command execution MCP server for Claude AI that enables controlled shell access within specified directories, providing safe command execution capabilities. ([Read more](/details/secure-shell-mcp-server.md)) `Shell` `Security` `Command Execution`
 - [Yepcode MCP Server JS](https://github.com/yepcode/mcp-server-js) - Execute LLM-generated code in secure scalable sandbox; create MCP tools with JavaScript or Python supporting NPM and PyPI packages. ([Read more](/details/yepcode-mcp-server-js.md)) `Javascript` `Python` `Sandbox` `Cloud` `Open Source`
+- [SandBase Harness](https://github.com/sandbaseai/sandbase-harness) - Local-first MCP bridge for governed agent sessions, approvals, credential management, audit/replay, and sandboxed execution through local, Docker, Kubernetes, or self-hosted worker backends. ([Read more](/details/sandbase-harness.md)) `Mcp` `Sandbox` `Code Execution` `Audit` `Open Source`
 
 ## Content Management
 

--- a/details/sandbase-harness.md
+++ b/details/sandbase-harness.md
@@ -1,0 +1,10 @@
+## Overview
+
+[SandBase Harness](https://github.com/sandbaseai/sandbase-harness) is a local-first agent runtime with an MCP bridge for governed tool access, persistent sessions, credential management, approvals, audit/replay, and sandboxed execution. The bridge is distributed as the multi-architecture OCI image `ghcr.io/sandbaseai/sandbase-harness-mcp:0.3.8`; the connected runtime can use local, Docker, Kubernetes, or self-hosted worker backends. Isolation properties depend on the selected backend and configuration.
+
+### Links
+
+- [Installation](https://github.com/sandbaseai/sandbase-harness/blob/main/README.md#installation)
+- [MCP setup](https://github.com/sandbaseai/sandbase-harness/blob/main/docs/mcp.md)
+- [Sandbox backends](https://github.com/sandbaseai/sandbase-harness/blob/main/docs/sandboxing.md)
+- [Latest release](https://github.com/sandbaseai/sandbase-harness/releases/latest)


### PR DESCRIPTION
## Summary\n- add SandBase Harness to Code Execution & Automation\n- add a source-linked detail page with installation, MCP, sandbox-backend, and release references\n\n## Verification\n-  passes\n- Project: https://github.com/sandbaseai/sandbase-harness\n- Installation: https://github.com/sandbaseai/sandbase-harness/blob/main/README.md#installation\n- MCP setup: https://github.com/sandbaseai/sandbase-harness/blob/main/docs/mcp.md\n- Sandbox backends: https://github.com/sandbaseai/sandbase-harness/blob/main/docs/sandboxing.md\n- Latest release: https://github.com/sandbaseai/sandbase-harness/releases/latest\n\nThe entry is factual and explicitly qualifies isolation as backend/configuration dependent.