### PR TITLE
Add Agent QA MCP Server to Testing & Debugging Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ The public-facing website is based on the open-source [Directory Website Templat
 - [Mcp Server Directories & Lists (2)](#mcp-server-directories--lists)
 - [Reference Implementations & Examples (55)](#reference-implementations--examples)
 - [Server Management Tools (9)](#server-management-tools)
-- [Testing & Debugging Tools (21)](#testing--debugging-tools)
+- [Testing & Debugging Tools (22)](#testing--debugging-tools)
 - [AI & LLM MCP Servers (12)](#ai--llm-mcp-servers)
 - [AI Agents & Orchestration MCP Servers (21)](#ai-agents--orchestration-mcp-servers)
 - [Automation (6)](#automation)
@@ -1476,6 +1476,7 @@ The public-facing website is based on the open-source [Directory Website Templat
 
 ## Testing & Debugging Tools
 
+- [Agent QA MCP Server](https://github.com/vostride/agent-qa) - Source-available MCP server for authoring, queuing, and inspecting natural-language web, Android, and iOS application tests. ([Read more](/details/agent-qa-mcp-server.md)) `Testing` `Mobile Testing` `Natural Language`
 - [Angie Jones Selenium MCP](https://github.com/angiejones/mcp-selenium) - Official Selenium MCP server enabling browser automation through Model Context Protocol for Selenium WebDriver, bringing industry-standard test automation to AI-powered workflows. ([Read more](/details/angie-jones-selenium-mcp.md)) `Selenium` `Webdriver` `Automation`
 - [Execute Automation Playwright MCP Server](https://github.com/executeautomation/mcp-playwright) - Comprehensive Playwright Model Context Protocol server with automatic browser installation, 143 device emulations including iPhone, iPad, Pixel, Galaxy, and desktop browsers for AI-powered browser automation and testing. ([Read more](/details/execute-automation-playwright-mcp-server.md)) `Testing` `Browser Automation` `Playwright`
 - [API Lab MCP](https://github.com/modelcontextprotocol/servers/tree/main/src/api-lab-mcp) - Transform Claude into an AI-powered API testing laboratory. Test, debug, and document APIs through natural conversation with authentication support, response validation, and performance metrics. ([Read more](/details/api-lab-mcp.md)) `Api Testing` `Debugging` `Documentation`

--- a/details/agent-qa-mcp-server.md
+++ b/details/agent-qa-mcp-server.md
@@ -1,0 +1,24 @@
+# Agent QA MCP Server
+
+Agent QA provides an MCP server that lets AI agents author, queue, and inspect natural-language application tests for web, Android, and iOS.
+
+## Features
+
+- Author and validate test definitions through MCP tools.
+- Queue test and suite runs, then inspect their steps, logs, and artifacts.
+- Retrieve structured run information for failure triage.
+- Use Agent QA's persistent execution memory and recovery from UI changes during test execution.
+
+## Integration
+
+The `@vostride/agent-qa-mcp` package ships with Agent QA. The `agent-qa mcp` CLI command starts a server over standard input/output for MCP clients. Authoring and run-management tools require a configured Agent QA dashboard service; execution also requires the appropriate model and browser or device providers.
+
+## License and Costs
+
+Agent QA is source-available under FSL-1.1-ALv2. Each release converts to Apache-2.0 after two years. There is no software fee for permitted use; configured model, browser, and device providers may charge separately.
+
+## Links
+
+- [Repository](https://github.com/vostride/agent-qa)
+- [Documentation](https://vostride.com/docs/agent-qa)
+- [MCP setup and tool reference](https://vostride.com/docs/agent-qa/mcp)


### PR DESCRIPTION
Add [Agent QA's MCP server](https://github.com/vostride/agent-qa) under Testing & Debugging Tools, create its detail page, and update that category's count from 21 to 22.

Agents use its MCP tools to author and queue natural-language web, Android, and iOS application tests, inspect execution evidence, and triage failures. The [MCP documentation](https://vostride.com/docs/agent-qa/mcp) covers the shipped server and client setup. The detail page explains the dashboard service and execution-provider requirements.

The entry says source-available, and the detail page identifies FSL-1.1-ALv2, each release's two-year conversion to Apache-2.0, and possible configured-provider charges. No software fee applies to permitted use.

Validation: checked the complete README and detail filenames for duplicates; verified the 22-entry category count and new local detail link; all 3 distinct added external URLs return HTTP 200. Whitespace checks pass, and all original README bytes outside the entry/count change are preserved. This repository does not contain a local build or test workflow.

Affiliation: I am affiliated with Vostride/Agent QA. This contribution was prepared with AI assistance.
